### PR TITLE
Added COJ (coj.uci.cu) to ###Sites to Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ It is advised that you write yours first before looking at others'.
 | ★★☆ | [Project Euler](https://projecteuler.net/) | Project Euler features a stunning set of good math problems. It also hosts a forum where people can discuss. |
 | ★☆☆ | [Hackerearth](https://www.hackerearth.com/) | HackerEarth is a startup technology company based in Bangalore, India that provides recruitment solutions. |
 | ★★☆ | [Aizu Online Judge](http://judge.u-aizu.ac.jp/onlinejudge/index.jsp) | Aizu online judge is a contest platform and problem archive hosted by The University of Aizu. It has a lot of great problems from programming competitions in Japan. |
+| ★☆☆ | [Caribbean Online Judge](http://coj.uci.cu) | COJ is hosted by University of Informatics Sciences (UCI, by its acronym in Spanish), located in Cuba. Feature ACM ICPC and Progresive constest styles, mostly from Caribbean and Latin America problem setters, also has problem classifier and contest calendar. |
 
 #### Problem Classifiers
 > Sites classifying programming problems.  


### PR DESCRIPTION
More info about COJ: 
- https://ciiwiki.ecs.baylor.edu/index.php/Caribbean_Online_Judge_%28COJ%29
- http://coj.uci.cu/general/about.xhtml
- http://coj.uci.cu/general/docs.xhtml
- http://coj.uci.cu/general/faqs.xhtml