### PR TITLE
Add CodeFights to Sites for Practice section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Share the list with your classmates, your friends and everyone :)
 | ★☆☆ | [Caribbean Online Judge](http://coj.uci.cu/index.xhtml) | COJ is hosted by University of Informatics Sciences (UCI, by its acronym in Spanish), located in Cuba. Feature ACM ICPC and Progresive constest styles, mostly from Caribbean and Latin American problem setters, also has problem classifier and contest calendar. |
 | ★★☆ | [CS Academy](https://csacademy.com) | New in the competitive programming scene, CS Academy is a growing online judge that hosts competitions once every two weeks. It supports live chat, interactive lessons and an integrated online editor (that actually works). |
 | ★★☆ | [Russian Code Cup](http://www.russiancodecup.ru/en/) | Programming competitions powered by Mail.Ru Group. Competition consists of 3 qualification, 1 elimination and 1 final rounds. For each round contestants are given 4-8 problems which must be solved in a fixed amount of time. |
+| ★★☆ | [CodeFights](https://codefights.com/) | CodeFights is a website for competitive programming practice and interview preparation. It features daily challenges of varying difficulty, an archive of problems and regular (every 15 minutes) mini-tournaments. Good for beginners. |
 
 ### Problem Classifiers
 > Sites classifying programming problems.  


### PR DESCRIPTION
CodeFights is one of the very few competitive programming websites which I still frequent. It is nicely gamified and helps to solve (at least) a problem a day. I think it's worth adding it to this list.

Disclaimer: I'm not affiliated with CodeFights organization, but I won several of their t-shirts.