### PR TITLE
Add competitiveprogramming.info/calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Choose a category (eg. DP) of interest and practice problems on that topic.
 | ★★☆ | [Coding Calendar (Android App)](https://play.google.com/store/apps/details?id=com.limitskyapps.CodingCalendar) |  |
 | ★★☆ | [Coder's Calendar](https://github.com/nishanthvijayan/CoderCalendar): [Android App](https://play.google.com/store/apps/details?id=com.corphots.coderscalendar), [Chrome Extension](https://chrome.google.com/webstore/detail/coders-calendar/bageaffklfkikjigoclfgengklfnidll), [Firefox Add-on](https://addons.mozilla.org/en-US/firefox/addon/coder-calendar/) |  |
 | ★★★ | [CodeHorizon](http://codehorizon.star-lord.me/): [iOS App](https://itunes.apple.com/in/app/codehorizon/id925056167?mt=8), [Android App](https://play.google.com/store/apps/details?id=com.chintanghate.CodeHorizon) |  |
+| ★★★ | [Competitive Programming Contests Calendar](https://competitiveprogramming.info/calendar) | Google Calendar export available |
 
 
 ## Sites for Questions


### PR DESCRIPTION
I would like to introduce a calendar on my site. It covers many short-period contests (AtCoder, Codeforces, Topcoder, LeetCode, and so on).