### PR TITLE
add: Codeforces Readme Stats tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Paste your codes at [ideone](https://ideone.com/), [pastebin](https://pastebin.c
 | ★★☆ | Code Sharing: ... [Ideone.com](https://ideone.com/) ... [Pastebin.com](https://pastebin.com/) ... [Ubuntu Pastebin](https://paste.ubuntu.com/) | These tools generate semi-permanent pages for code sharing. Very useful especially when you're trying to get someone else to look into your code. |
 | ★★☆ | [Ineffable](http://codeforces.com/blog/entry/19083) | A simple command-line grader for local grading. |
 | ★★☆ | [uDebug](https://www.udebug.com/) | A platform that provides expected outputs for user-specified inputs to problems on the UVa Online Judge. Some problems also provide additional test cases for debugging. |
+| ★★☆ | [Codeforces Readme Stats](https://redheadphone.github.io/Codeforces-readme-stats/) | An API that generates an image containing compiled statistics of a Codeforces profile that can be added to a user's GitHub Readme. |
 
 ### Contest Preparation
 


### PR DESCRIPTION
It's awesome because it allows competitive programmers to showcase their skills and achievements to potential recruiters and fellow programmers by including their Codeforces profile stats in their github README. 

This project, which I created, is a great tool that automatically generates beautiful statistics of your Codeforces profile, which can be added to your README to create a stunning profile that highlights your skills and achievements.